### PR TITLE
Create Makefile and define interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ $(call config_option_s,i,	TEST_ROMFS_TEMPDIR,	$(INTERMEDIATE_DIR)/test-romfs)
 $(call config_option_t,i,	TARGET,			build,						test)
 
 # name and place to outptu binaries to. File extensions are appended automatically.
-$(call config_option_t,i,	OUTPUT,			$(notdir $(CURDIR)),		$(notdir $(CURDIR))_capture)
+$(call config_option_t,ie,	OUTPUT,			$(notdir $(CURDIR)),		$(notdir $(CURDIR))_capture)
 
 # Directories for various files.
 $(call config_option_t,i,	SOURCES,		$(shell find source -type d -print), $(shell find test -type d -print))
@@ -45,30 +45,30 @@ $(call config_option_t,i,	ROMFS_DIR,		romfs,						romfs)
 
 # Settings for cia and cci. If the given rsf doesn't take command line options PRODUCTCODE and UniqeID
 # can be ignored.
-$(call config_option_t,i,	PRODUCTCODE,	CTR-P-CTAP,				CTR-P-CTAP)
-$(call config_option_t,i,	UNIQUEID,		6d40a6,						6b40a6)
-$(call config_option_t,i,	RSFFILE,		assets/Application.rsf,		assets/Application.rsf)
-$(call config_option_t,i,	BANNER_IMAGE,	assets/image.png,		assets/image.png)
-$(call config_option_t,i,	BANNER_AUDIO,	assets/audio.wav,		assets/audio.wav)
+$(call config_option_t,ie,	PRODUCTCODE,	CTR-P-CTAP,				CTR-P-CTAP)
+$(call config_option_t,ie,	UNIQUEID,		6d40a6,						6b40a6)
+$(call config_option_t,ie,	RSFFILE,		assets/Application.rsf,		assets/Application.rsf)
+$(call config_option_t,ie,	BANNER_IMAGE,	assets/image.png,		assets/image.png)
+$(call config_option_t,ie,	BANNER_AUDIO,	assets/audio.wav,		assets/audio.wav)
 
 # Settings for 3dsx files. Unlike in the example Makefile, these values don't default if left
 # empty.
-$(call config_option_t,i,	APP_TITLE,		$(notdir $(CURDIR)),		$(notdir $(CURDIR))_capture)
-$(call config_option_t,i,	APP_DESCRIPTION,Built with devkitARM & libctru,	Built with devkitARM & libctru)
-$(call config_option_t,i,	APP_AUTHOR,		Unspecified Author,		Unspecified Author)
-$(call config_option_t,i,	APP_ICON,		$(CTRULIB)/default_icon.png,	$(CTRULIB)/default_icon.png)
+$(call config_option_t,ie,	APP_TITLE,		$(notdir $(CURDIR)),		$(notdir $(CURDIR))_capture)
+$(call config_option_t,ie,	APP_DESCRIPTION,Built with devkitARM & libctru,	Built with devkitARM & libctru)
+$(call config_option_t,ie,	APP_AUTHOR,		Unspecified Author,		Unspecified Author)
+$(call config_option_t,ie,	APP_ICON,		$(CTRULIB)/default_icon.png,	$(CTRULIB)/default_icon.png)
 
 # Compiler flags. Be sure to escape variable references in CXXFLAGS.
-$(call config_option_t,i,	ARCH,			-march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft)
-$(call config_option_t,i,	CFLAGS,			-g -Wall -O2 -mword-relocations -ffunction-sections $(BUILD_ARCH), \
+$(call config_option_t,ie,	ARCH,			-march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft)
+$(call config_option_t,ie,	CFLAGS,			-g -Wall -O2 -mword-relocations -ffunction-sections $(BUILD_ARCH), \
 											-g -Wall -O2 -mword-relocations -ffunction-sections $(TEST_ARCH))
 
-$(call config_option_t,,	CXXFLAGS,		$$(BUILD_CFLAGS) -DCATCH_CONFIG_NO_POSIX_SIGNALS -DCATCH_CONFIG_COLOUR_ANSI -DCATCH_CONFIG_CONSOLE_WIDTH=50 -std=gnu++17 \
+$(call config_option_t, e,	CXXFLAGS,		$$(BUILD_CFLAGS) -DCATCH_CONFIG_NO_POSIX_SIGNALS -DCATCH_CONFIG_COLOUR_ANSI -DCATCH_CONFIG_CONSOLE_WIDTH=50 -std=gnu++17 \
 											$$(TEST_CFLAGS)	-DCATCH_CONFIG_NO_POSIX_SIGNALS -DCATCH_CONFIG_COLOUR_ANSI -DCATCH_CONFIG_CONSOLE_WIDTH=50 -std=gnu++17)
-$(call config_option_t,i,	ASFLAGS,		-g $(BUILD_ARCH),		-g $(TEST_ARCH))
-$(call config_option_t,i,	LDFLAGS,		-specs=3dsx.specs -g $(BUILD_ARCH) -Wl$(,)-Map$(,)$(OUTPUT_DIR)/$(notdir $*.map), \
+$(call config_option_t,ie,	ASFLAGS,		-g $(BUILD_ARCH),		-g $(TEST_ARCH))
+$(call config_option_t,ie,	LDFLAGS,		-specs=3dsx.specs -g $(BUILD_ARCH) -Wl$(,)-Map$(,)$(OUTPUT_DIR)/$(notdir $*.map), \
 											-specs=3dsx.specs -g $(TEST_ARCH)  -Wl$(,)-Map$(,)$(OUTPUT_DIR)/$(notdir $*.map))
-$(call config_option_t,i,	LIBS,			-lctru -lm,				)
+$(call config_option_t,ie,	LIBS,			-lctru -lm,				)
 $(call config_option_t,i,	LIBDIRS,		$(CTRULIB),				)
 
 #---------------------------------------------------------------------------------
@@ -106,6 +106,8 @@ $(call eval_no_target,TEST,CCI)
 $(call gen_3dsxflags,BUILD)
 $(call gen_3dsxflags,TEST)
 
+VARS_TO_OVERRIDE += _3DSXFLAGS
+
 ####################################
 # TODO: HFILES IS NOT YET BEING GENERATED CORRECTLY
 #	HFILES is currently in the same directory as its sources.
@@ -131,9 +133,7 @@ create_filelists = \
 
 $(call create_filelists,BUILD)
 $(call create_filelists,TEST)
-
-$(info $(BUILD_INCLUDE))
-$(info $(BUILD_INCLUDES))
+VARS_TO_OVERRIDE 				+= OFILES LIBPATHS
 
 #---------------------------------------------------------------------------------
 # MERGING BUILD AND TEST VARS
@@ -207,6 +207,8 @@ $(TEST_ROMFS_TEMPDIR): $(BUILD_ROMFS_DIR) $(TEST_ROMFS_DIR)
 	 cp -r $(TEST_ROMFS_DIR)/* $(TEST_ROMFS_DIR)/.[^.]* $@ && \
 	 echo Rebuilt test-romfs.
 
+VARS_TO_OVERRIDE += ROMFS
+
 #---------------------------------------------------------------------------------
 # DEPENDENCY INJECTION
 # Target-Specific variables are also in effect for all prerequisites of the specified
@@ -215,29 +217,8 @@ $(TEST_ROMFS_TEMPDIR): $(BUILD_ROMFS_DIR) $(TEST_ROMFS_DIR)
 
 BUILD_LD				= $(if $(BUILD_CPPFILES),$(CXX),$(CC))
 TEST_LD					= $(if $(TEST_CPPFILES),$(CXX),$(CC))
+VARS_TO_OVERRIDE		+= LD
 
-VARS_TO_OVERRIDE := \
-	OUTPUT \
-	PRODUCTCODE \
-	ROMFS \
-	UNIQUEID \
-	APP_TITLE \
-	APP_DESCRIPTION \
-	APP_AUTHOR \
-	APP_ICON \
-	RSFFILE \
-	BANNER_AUDIO \
-	BANNER_IMAGE \
-	ARCH \
-	CFLAGS \
-	CXXFLAGS \
-	ASFLAGS \
-	LDFLAGS \
-	LIBS \
-	LIBPATHS \
-	_3DSXFLAGS \
-	OFILES \
-	LD
 $(call override_values,$(VARS_TO_OVERRIDE))
 
 $(BUILD_OUTPUT).elf: $(BUILD_OFILES)

--- a/Makefile
+++ b/Makefile
@@ -14,36 +14,51 @@ include $(MAKEMODULES_DIR)/AssertEnvironment
 #include $(MAKEMODULES_DIR)/AssertParameters
 
 #---------------------------------------------------------------------------------
-# TOOLING CONFIGURATION
-# All these values are defined to be either a possibly exported value or the
-# second parameter.
-#- VARIABLE_NAME ----- IMMEDIATE ?= ----- VARIABLE_NAME ------- VALUE ------------
+# GENERAL CONFIGURATION
+#	Configures directories and tools for the build.
+#--------------------------- NAME -------------- VALUE ---------------------------
+# Makerom and bannertool are the commands to launch those tools. 
 $(call config_option_s,i,	MAKEROM,			makerom)
 $(call config_option_s,i,	BANNERTOOL,			bannertool)
-$(call config_option_s,i,	INTERMEDIATE_DIR,	build)
+
 $(call config_option_s,i,	OUTPUT_DIR,			output)
+$(call config_option_s,i,	INTERMEDIATE_DIR,	build)
 $(call config_option_s,i,	OFILES_DIR,			$(INTERMEDIATE_DIR)/build)
 $(call config_option_s,i,	PATCHED_MAKE_DIR,	$(INTERMEDIATE_DIR)/makefiles)
 $(call config_option_s,i,	DEPSDIR,			$(INTERMEDIATE_DIR)/deps)
 $(call config_option_s,i,	TEST_ROMFS_TEMPDIR,	$(INTERMEDIATE_DIR)/test-romfs)
+
 #---------------------------------------------------------------------------------
 # REGULAR CONFIGURATION
-#----------------------- NAME --- VALUE FOR REGULAR BUILDS ---- VALUE FOR TEST BUILDS
-$(call config_option_t,i,TARGET,	build,						test)
-$(call config_option_t,i,OUTPUT,	$(notdir $(CURDIR)),		$(notdir $(CURDIR))_capture)
-$(call config_option_t,i,SOURCES,	$(shell find source -type d -print), $(shell find test -type d -print))
-$(call config_option_t,i,INCLUDES,	include Catch/single_include cpptoml/include, cpptoml/include, Catch/single_include)
-$(call config_option_t,i,DATA,		data,						test-data)
-$(call config_option_t,i,PRODUCTCODE,	CTR-P-CTAP,				CTR-P-CTAP)
-$(call config_option_t,i,ROMFS_DIR,	romfs,						romfs)
-$(call config_option_t,i,UNIQUEID,	6d40a6,						6b40a6)
-$(call config_option_t,i,RSFFILE,	assets/Application.rsf,		assets/Application.rsf)
-$(call config_option_t,i,APP_TITLE,	$(notdir $(CURDIR)),		$(notdir $(CURDIR))_capture)
+#-------------------------- NAME ---------- VALUE FOR REGULAR BUILDS -- VALUE FOR TEST BUILDS
+# The command to build the regular and test targets.
+$(call config_option_t,i,	TARGET,			build,						test)
+
+# name and place to outptu binaries to. File extensions are appended automatically.
+$(call config_option_t,i,OUTPUT,			$(notdir $(CURDIR)),		$(notdir $(CURDIR))_capture)
+
+# Directories for various files.
+$(call config_option_t,i,SOURCES,			$(shell find source -type d -print), $(shell find test -type d -print))
+$(call config_option_t,i,INCLUDES,			include Catch/single_include cpptoml/include, cpptoml/include, Catch/single_include)
+$(call config_option_t,i,DATA,				data,						test-data)
+$(call config_option_t,i,ROMFS_DIR,			romfs,						romfs)
+
+# Settings for cia and cci. If the given rsf doesn't take command line options PRODUCTCODE and UniqeID
+# can be ignored.
+$(call config_option_t,i,PRODUCTCODE,		CTR-P-CTAP,				CTR-P-CTAP)
+$(call config_option_t,i,UNIQUEID,			6d40a6,						6b40a6)
+$(call config_option_t,i,RSFFILE,			assets/Application.rsf,		assets/Application.rsf)
+$(call config_option_t,i,BANNER_IMAGE,		assets/image.png,		assets/image.png)
+$(call config_option_t,i,BANNER_AUDIO,		assets/audio.wav,		assets/audio.wav)
+
+# Settings for 3dsx files. Unlike in the example Makefile, these values don't default if left
+# empty.
+$(call config_option_t,i,APP_TITLE,			$(notdir $(CURDIR)),		$(notdir $(CURDIR))_capture)
 $(call config_option_t,i,APP_DESCRIPTION,	Built with devkitARM & libctru,	Built with devkitARM & libctru)
-$(call config_option_t,i,APP_AUTHOR,	Unspecified Author,		Unspecified Author)
-$(call config_option_t,i,APP_ICON,	$(CTRULIB)/default_icon.png,	$(CTRULIB)/default_icon.png)
-$(call config_option_t,i,BANNER_IMAGE,	assets/image.png,		assets/image.png)
-$(call config_option_t,i,BANNER_AUDIO,	assets/audio.wav,		assets/audio.wav)
+$(call config_option_t,i,APP_AUTHOR,		Unspecified Author,		Unspecified Author)
+$(call config_option_t,i,APP_ICON,			$(CTRULIB)/default_icon.png,	$(CTRULIB)/default_icon.png)
+
+# Compiler flags. Be sure to escape variable references in CXXFLAGS.
 $(call config_option_t,i,ARCH,			-march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft)
 $(call config_option_t,i,CFLAGS,		-g -Wall -O2 -mword-relocations -ffunction-sections $(BUILD_ARCH), \
 										-g -Wall -O2 -mword-relocations -ffunction-sections $(TEST_ARCH))
@@ -56,7 +71,7 @@ $(call config_option_t,i,LDFLAGS,		-specs=3dsx.specs -g $(BUILD_ARCH) -Wl$(,)-Ma
 $(call config_option_t,i,LIBS,			-lctru -lm,				)
 $(call config_option_t,i,LIBDIRS,		$(CTRULIB),				)
 
-
+#---------------------------------------------------------------------------------
 
 .DEFAULT_GOAL 		:= all
 

--- a/Makefile
+++ b/Makefile
@@ -35,41 +35,41 @@ $(call config_option_s,i,	TEST_ROMFS_TEMPDIR,	$(INTERMEDIATE_DIR)/test-romfs)
 $(call config_option_t,i,	TARGET,			build,						test)
 
 # name and place to outptu binaries to. File extensions are appended automatically.
-$(call config_option_t,i,OUTPUT,			$(notdir $(CURDIR)),		$(notdir $(CURDIR))_capture)
+$(call config_option_t,i,	OUTPUT,			$(notdir $(CURDIR)),		$(notdir $(CURDIR))_capture)
 
 # Directories for various files.
-$(call config_option_t,i,SOURCES,			$(shell find source -type d -print), $(shell find test -type d -print))
-$(call config_option_t,i,INCLUDES,			include Catch/single_include cpptoml/include, cpptoml/include, Catch/single_include)
-$(call config_option_t,i,DATA,				data,						test-data)
-$(call config_option_t,i,ROMFS_DIR,			romfs,						romfs)
+$(call config_option_t,i,	SOURCES,		$(shell find source -type d -print), $(shell find test -type d -print))
+$(call config_option_t,i,	INCLUDES,		include Catch/single_include cpptoml/include, cpptoml/include, Catch/single_include)
+$(call config_option_t,i,	DATA,			data,						test-data)
+$(call config_option_t,i,	ROMFS_DIR,		romfs,						romfs)
 
 # Settings for cia and cci. If the given rsf doesn't take command line options PRODUCTCODE and UniqeID
 # can be ignored.
-$(call config_option_t,i,PRODUCTCODE,		CTR-P-CTAP,				CTR-P-CTAP)
-$(call config_option_t,i,UNIQUEID,			6d40a6,						6b40a6)
-$(call config_option_t,i,RSFFILE,			assets/Application.rsf,		assets/Application.rsf)
-$(call config_option_t,i,BANNER_IMAGE,		assets/image.png,		assets/image.png)
-$(call config_option_t,i,BANNER_AUDIO,		assets/audio.wav,		assets/audio.wav)
+$(call config_option_t,i,	PRODUCTCODE,	CTR-P-CTAP,				CTR-P-CTAP)
+$(call config_option_t,i,	UNIQUEID,		6d40a6,						6b40a6)
+$(call config_option_t,i,	RSFFILE,		assets/Application.rsf,		assets/Application.rsf)
+$(call config_option_t,i,	BANNER_IMAGE,	assets/image.png,		assets/image.png)
+$(call config_option_t,i,	BANNER_AUDIO,	assets/audio.wav,		assets/audio.wav)
 
 # Settings for 3dsx files. Unlike in the example Makefile, these values don't default if left
 # empty.
-$(call config_option_t,i,APP_TITLE,			$(notdir $(CURDIR)),		$(notdir $(CURDIR))_capture)
-$(call config_option_t,i,APP_DESCRIPTION,	Built with devkitARM & libctru,	Built with devkitARM & libctru)
-$(call config_option_t,i,APP_AUTHOR,		Unspecified Author,		Unspecified Author)
-$(call config_option_t,i,APP_ICON,			$(CTRULIB)/default_icon.png,	$(CTRULIB)/default_icon.png)
+$(call config_option_t,i,	APP_TITLE,		$(notdir $(CURDIR)),		$(notdir $(CURDIR))_capture)
+$(call config_option_t,i,	APP_DESCRIPTION,Built with devkitARM & libctru,	Built with devkitARM & libctru)
+$(call config_option_t,i,	APP_AUTHOR,		Unspecified Author,		Unspecified Author)
+$(call config_option_t,i,	APP_ICON,		$(CTRULIB)/default_icon.png,	$(CTRULIB)/default_icon.png)
 
 # Compiler flags. Be sure to escape variable references in CXXFLAGS.
-$(call config_option_t,i,ARCH,			-march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft)
-$(call config_option_t,i,CFLAGS,		-g -Wall -O2 -mword-relocations -ffunction-sections $(BUILD_ARCH), \
-										-g -Wall -O2 -mword-relocations -ffunction-sections $(TEST_ARCH))
+$(call config_option_t,i,	ARCH,			-march=armv6k -mtune=mpcore -mfloat-abi=hard -mtp=soft)
+$(call config_option_t,i,	CFLAGS,			-g -Wall -O2 -mword-relocations -ffunction-sections $(BUILD_ARCH), \
+											-g -Wall -O2 -mword-relocations -ffunction-sections $(TEST_ARCH))
 
-$(call config_option_t,,CXXFLAGS,		$$(BUILD_CFLAGS) -DCATCH_CONFIG_NO_POSIX_SIGNALS -DCATCH_CONFIG_COLOUR_ANSI -DCATCH_CONFIG_CONSOLE_WIDTH=50 -std=gnu++17 \
-										$$(TEST_CFLAGS)	-DCATCH_CONFIG_NO_POSIX_SIGNALS -DCATCH_CONFIG_COLOUR_ANSI -DCATCH_CONFIG_CONSOLE_WIDTH=50 -std=gnu++17)
-$(call config_option_t,i,ASFLAGS,		-g $(BUILD_ARCH),		-g $(TEST_ARCH))
-$(call config_option_t,i,LDFLAGS,		-specs=3dsx.specs -g $(BUILD_ARCH) -Wl$(,)-Map$(,)$(OUTPUT_DIR)/$(notdir $*.map), \
-										-specs=3dsx.specs -g $(TEST_ARCH)  -Wl$(,)-Map$(,)$(OUTPUT_DIR)/$(notdir $*.map))
-$(call config_option_t,i,LIBS,			-lctru -lm,				)
-$(call config_option_t,i,LIBDIRS,		$(CTRULIB),				)
+$(call config_option_t,,	CXXFLAGS,		$$(BUILD_CFLAGS) -DCATCH_CONFIG_NO_POSIX_SIGNALS -DCATCH_CONFIG_COLOUR_ANSI -DCATCH_CONFIG_CONSOLE_WIDTH=50 -std=gnu++17 \
+											$$(TEST_CFLAGS)	-DCATCH_CONFIG_NO_POSIX_SIGNALS -DCATCH_CONFIG_COLOUR_ANSI -DCATCH_CONFIG_CONSOLE_WIDTH=50 -std=gnu++17)
+$(call config_option_t,i,	ASFLAGS,		-g $(BUILD_ARCH),		-g $(TEST_ARCH))
+$(call config_option_t,i,	LDFLAGS,		-specs=3dsx.specs -g $(BUILD_ARCH) -Wl$(,)-Map$(,)$(OUTPUT_DIR)/$(notdir $*.map), \
+											-specs=3dsx.specs -g $(TEST_ARCH)  -Wl$(,)-Map$(,)$(OUTPUT_DIR)/$(notdir $*.map))
+$(call config_option_t,i,	LIBS,			-lctru -lm,				)
+$(call config_option_t,i,	LIBDIRS,		$(CTRULIB),				)
 
 #---------------------------------------------------------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,15 @@ include $(MAKEMODULES_DIR)/AssertEnvironment
 #include $(MAKEMODULES_DIR)/AssertParameters
 
 #---------------------------------------------------------------------------------
-# REGULAR CONFIGURATION
+# TOOLING CONFIGURATION
 # All these values are defined to be either a possibly exported value or the
 # second parameter.
+#- VARIABLE_NAME ----- IMMEDIATE ?= ----- VARIABLE_NAME ------- VALUE ------------
+MAKEROM				:= $(call or_default, MAKEROM,				makerom)
+BANNERTOOL			:= $(call or_default, BANNERTOOL,			bannertool)
+
+#---------------------------------------------------------------------------------
+# REGULAR CONFIGURATION
 #- VARIABLE_NAME ----- IMMEDIATE ?= ----- VARIABLE_NAME ------- VALUE ------------
 BUILD_TARGET		:= $(call or_default, BUILD_TARGET, 		build)
 
@@ -24,29 +30,42 @@ BUILD_OUTPUT		:= $(call or_default, BUILD_OUTPUT, 		$(notdir $(CURDIR)))
 
 BUILD_SOURCES		:= $(call or_default, BUILD_SOURCES, 		$(shell find source -type d -print))
 
-BUILD_INCLUDES		:= $(call or_default, BUILD_INCLUDES, 		include)
+BUILD_INCLUDES		:= $(call or_default, BUILD_INCLUDES, 		include \
+																Catch/single_include \
+																cpptoml/include)
 
 BUILD_DATA			:= $(call or_default, BUILD_DATA, 			data)
 
 BUILD_PRODUCTCODE	:= $(call or_default, BUILD_PRODUCTCODE,	CTR-P-CTAP)
 BUILD_ROMFS_DIR		:= $(call or_default, BUILD_ROMFS_DIR,		romfs)
 BUILD_UNIQUEID		:= $(call or_default, BUILD_UNIQUEID, 		6d40a6)
+BUILD_RSFFILE		:= $(call or_default, BUILD_RSFFILE,		assets/Application.rsf)
 
-BUILD_ARCH			:= $(call or_default, BUILD_ARCH, 			-march-armv6k \
+BUILD_APP_TITLE		:= $(call or_default, BUILD_APP_TITLE,		$(notdir $(CURDIR)))
+BUILD_APP_DESCRIPTION := $(call or_default,BUILD_APP_DESCRIPTION, Built with devkitARM & libctru)
+BUILD_APP_AUTHOR	:= $(call or_default,						Unspecified Author)
+BUILD_APP_ICON		:= $(call or_default, BUILD_APP_ICON,		$(CTRULIB)/default_icon.png)
+
+BUILD_BANNER_IMAGE	:= $(call or_default, BUILD_BANNER_IMAGE,	assets/image.png)
+BUILD_BANNER_AUDIO	:= $(call or_default, BUILD_BANNER_AUDIO,	assets/audio.wav)
+
+BUILD_ARCH			:= $(call or_default, BUILD_ARCH, 			-march=armv6k \
 																-mtune=mpcore \
 																-mfloat-abi=hard \
 																-mtp=soft)
 
 BUILD_CFLAGS		:= $(call or_default, BUILD_CFLAGS,			-g -Wall -O2 -mword-relocations \
-																-fomit-frame-pointer -ffunction-sections) \
+																-ffunction-sections) \
 																$(BUILD_ARCH)
 
-BUILD_CXXFLAGS		:= $(call or_default, BUILD_CXXFLAGS,		$(BUILD_CFLAGS) \
-																-fno-rtti \
-																-fno-exceptions \
-																-std=gnu++11)
+BUILD_CXXFLAGS		?=											$(BUILD_CFLAGS) \
+																-DCATCH_CONFIG_NO_POSIX_SIGNALS \
+																-DCATCH_CONFIG_COLOUR_ANSI \
+																-DCATCH_CONFIG_CONSOLE_WIDTH=50 \
+																-std=gnu++17
+																
 BUILD_ASFLAGS		:= $(call or_default, BUILD_ASFLAGS,		-g $(BUILD_ARCH))
-BUILD_LDFLAGS		?= -specs=3dsx.specs -g $(BUILD_ARCH) -Wl,Map,$(notdir $*.map)
+BUILD_LDFLAGS		?= -specs=3dsx.specs -g $(BUILD_ARCH) -Wl,-Map,$(OUTPUT_DIR)/$(notdir $*.map)
 
 BUILD_LIBS			:= $(call or_default, BUILD_LIBS,			-lctru -lm)
 BUILD_LIBDIRS		:= $(call or_default, BUILD_LIBDIRS,		$(CTRULIB))
@@ -54,7 +73,7 @@ BUILD_LIBDIRS		:= $(call or_default, BUILD_LIBDIRS,		$(CTRULIB))
 # BUILD_NO_3DSX		:= 1
 # BUILD_NO_SMDH		:= 1
 # BUILD_NO_CIA		:= 1
-# BUILD_NOT_CCI		:= 1
+# BUILD_NO_CCI		:= 1
 
 #---------------------------------------------------------------------------------
 # TEST CONFIGURATION
@@ -81,21 +100,26 @@ TEST_DATA			:= $(call or_default, TEST_DATA, 			test-data)
 TEST_PRODUCTCODE	:= $(call or_default, TEST_PRODUCTCODE, 	CTR-P-CTAP)
 TEST_ROMFS_DIR		:= $(call or_default, TEST_ROMFS_DIR,		romfs)
 TEST_UNIQUEID		:= $(call or_default, TEST_UNIQUEID, 		6b40a6)
+TEST_RSFFILE		:= $(call or_default, TEST_RSFFILE,			assets/Application.rsf)
 
-TEST_ARCH			:= $(call or_default, TEST_ARCH, 			-march-armv6k \
+BUILD_BANNER_IMAGE	:= $(call or_default, BUILD_BANNER_IMAGE,	assets/image.png)
+BUILD_BANNER_AUDIO	:= $(call or_default, BUILD_BANNER_AUDIO,	assets/audio.wav)
+
+TEST_ARCH			:= $(call or_default, TEST_ARCH, 			-march=armv6k \
 																-mtune=mpcore \
 																-mfloat-abi=hard \
 																-mtp=soft)
 
-TEST_CFLAGS		:= $(call or_default, TEST_CFLAGS,				-g -Wall -O2 -mword-relocations \
+TEST_CFLAGS			:= $(call or_default, TEST_CFLAGS,			-g -Wall -O2 -mword-relocations \
 																-fomit-frame-pointer -ffunction-sections) \
 																$(TEST_ARCH)
 
-TEST_CXXFLAGS		:= $(call or_default, TEST_CXXFLAGS,		$(TEST_CFLAGS) \
+TEST_CXXFLAGS		?=											$(TEST_CFLAGS) \
 																-fno-rtti \
-																-std=gnu++17)
+																-std=gnu++17
+
 TEST_ASFLAGS		:= $(call or_default, TEST_ASFLAGS,			-g $(TEST_ARCH))
-TEST_LDFLAGS		?= -specs=3dsx.specs -g $(TEST_ARCH) -Wl,Map,$(notdir $*.map)
+TEST_LDFLAGS		?= -specs=3dsx.specs -g $(TEST_ARCH) -Wl,-Map,$(OUTPUT_DIR)/$(notdir $*.map)
 
 TEST_LIBS			:= $(call or_default, TEST_LIBS,			)
 TEST_LIBDIRS		:= $(call or_default, TEST_LIBDIRS,			)
@@ -111,11 +135,16 @@ OUTPUT_DIR			:= $(call or_default, OUTPUT_DIR,			output)
 OFILES_DIR			:= $(call or_default, OFILES_DIR,			$(INTERMEDIATE_DIR)/build)
 PATCHED_MAKE_DIR	:= $(call or_default, PATCHED_MAKE_DIR,		$(INTERMEDIATE_DIR)/makefiles)
 _3DS_RULES			:= $(call or_default, _3DS_RULES,			$(PATCHED_MAKE_DIR)/3ds-rules)
-BASE_RULES			:= $(call or_default, BASE_RULES,			$(PATCHED_MAKE_DIR)/base_rules)
+BASE_RULES			:= $(call or_default, BASE_RULES,			$(PATCHED_MAKE_DIR)/base-rules)
 DEPSDIR				:= $(call or_default, DEPSDIR,				$(INTERMEDIATE_DIR)/deps)
 TEST_ROMFS_TEMPDIR	:= $(call or_default, TEST_ROMFS_TEMPDIR,	$(INTERMEDIATE_DIR)/test-romfs)
 DUMMY_APP_ICON		:= $(call or_default, DUMMY_APP_ICON,		$(INTERMEDIATE_DIR)/dummy-app-icon)
 #---------------------------------------------------------------------------------
+
+.DEFAULT_GOAL 		:= all
+include $(BASE_RULES)
+include $(_3DS_RULES)
+
 
 BUILD_3DSX_NAME 	:= $(BUILD_OUTPUT).3dsx
 BUILD_SMDH_NAME		:= $(BUILD_OUTPUT).smdh
@@ -161,9 +190,9 @@ create_filelists = \
 	$(eval $(1)_OFILES 			:= $($1_OFILES_BIN) $($1_OFILES_SOURCES)) \
 	$(eval $(1)_HFILES			:= $($1_PICAFILES:.v.pica=_shbin.h) $($1_SHLISTFILES:.shlist=_shbin.h) $(addsuffix .h,$(subst .,_,$($1_BINFILES)))) \
 	$(eval $(1)_INCLUDE			:= $(foreach dir,$($1_INCLUDES),-I$(dir)) \
-		$(foreach dir,$($1_LIBDIRS),-I$(dir)/include) -I$($1_BUILD))
+		$(foreach dir,$($1_LIBDIRS),-I$(dir)/include) -I$($1_BUILD)) \
+	$(eval $(1)_LIBPATHS		:= $(foreach dir,$($(1)_LIBDIRS),-L$(dir)/lib))
 
-LD					:= $(if $(CPPFILES),$(CXX),$(CC))
 
 $(call create_filelists,BUILD)
 $(call create_filelists,TEST)
@@ -178,11 +207,19 @@ TEST_OFILES_BIN					+= $(BUILD_OFILES_BIN)
 TEST_OFILES						:= $(TEST_OFILES_BIN) $(TEST_OFILES_SOURCES)
 TEST_HFILES						+= $(BUILD_OFILES)
 TEST_INCLUDE					+= $(BUILD_INCLUDE)
+TEST_LIBPATHS					+= $(BUILD_LIBPATHS)
 
 #---------------------------------------------------------------------------------
-# DEFINE REQUIRED DIRECTORIES
+# Finalizing CFLAGS
 #---------------------------------------------------------------------------------
-REQUIRED_DIRS := \
+
+BUILD_CFLAGS					+= $(BUILD_INCLUDE) -DARM11 -D_3DS 
+TEST_CFLAGS 					+= $(TEST_INCLUDE) -DARM11 -D_3DS
+
+#---------------------------------------------------------------------------------
+# CREATE REQUIRED DIRECTORIES
+#---------------------------------------------------------------------------------
+REQUIRED_DIRS := $(sort \
 $(dir $(BUILD_OUTPUT)) \
 $(dir $(TEST_OUTPUT)) \
 $(dir $(BUILD_OFILES)) \
@@ -192,10 +229,10 @@ $(OUTPUT_DIR) \
 $(PATCHED_MAKE_DIR) \
 $(dir $(_3DS_RULES)) \
 $(dir $(BASE_RULES)) \
-$(DEPSDIR) \
-$(foreach dir,$(shell find $(BUILD_ROMFS) $(TEST_ROMFS) -type d -print),$(TEST_ROMFS_TEMPDIR)/$(dir)) \
-$(dir $(DUMMY_APP_ICON))
+$(subst $(OFILES_DIR),$(DEPSDIR),$(sort $(dir $(BUILD_OFILES) $(TEST_OFILES)))) \
+$(dir $(DUMMY_APP_ICON)))
 
+_MKDIRS := $(shell mkdir -p $(REQUIRED_DIRS))
 #---------------------------------------------------------------------------------
 # TARGETS
 #---------------------------------------------------------------------------------
@@ -208,8 +245,8 @@ clean:
 	@$(RM) -r $(INTERMEDIATE_DIR)
 	@$(RM) -r $(OUTPUT_DIR)
 
-$(BUILD_TARGET): $(BUILD_3DSX) $(BUILD_SMDH) $(BUILD_CIA) $(BUILD_CCI) | $(REQUIRED_DIRS)
-$(TEST_TARGET): $(TEST_3DSX) $(TEST_SMDH) $(TEST_CIA) $(TEST_CCI) | $(REQUIRED_DIRS)
+$(BUILD_TARGET): $(BUILD_3DSX) $(BUILD_SMDH) $(BUILD_CIA) $(BUILD_CCI)
+$(TEST_TARGET): $(TEST_3DSX) $(TEST_SMDH) $(TEST_CIA) $(TEST_CCI)
 
 #---------------------------------------------------------------------------------
 # ROMFS GENERATION
@@ -227,24 +264,19 @@ $(BUILD_ROMFS_DIR): $(wildcard $(BUILD_ROMFS)/**/)
 $(TEST_ROMFS_DIR): $(wildcard $(TEST_ROMFS)/**/)
 $(TEST_ROMFS_TEMPDIR): $(BUILD_ROMFS_DIR) $(TEST_ROMFS_DIR)
 	@shopt -s nullglob && \
+	 mkdir -p $(sort $(dir $^))
 	 cp -r $(BUILD_ROMFS_DIR)/* $(BUILD_ROMFS_DIR)/.[^.]* $@ && \
 	 cp -r $(TEST_ROMFS_DIR)/* $(TEST_ROMFS_DIR)/.[^.]* $@ && \
 	 echo Rebuilt test-romfs.
-
-
-#---------------------------------------------------------------------------------
-# DIRECTORY GENERATION
-# This section ensures that all intermediate and output directories are available.
-#---------------------------------------------------------------------------------
-
-$(REQUIRED_DIRS):
-	@mkdir -p $@
 
 #---------------------------------------------------------------------------------
 # DEPENDENCY INJECTION
 # Target-Specific variables are also in effect for all prerequisites of the specified
 # target. This means they are inherited and can thus be set on the phony target.
 #---------------------------------------------------------------------------------
+
+BUILD_LD				= $(if $(BUILD_CPPFILES),$(CXX),$(CC))
+TEST_LD					= $(if $(TEST_CPPFILES),$(CXX),$(CC))
 
 VARS_TO_OVERRIDE := \
 	OUTPUT \
@@ -255,16 +287,23 @@ VARS_TO_OVERRIDE := \
 	APP_DESCRIPTION \
 	APP_AUTHOR \
 	APP_ICON \
+	RSFFILE \
+	BANNER_AUDIO \
+	BANNER_IMAGE \
 	ARCH \
 	CFLAGS \
 	CXXFLAGS \
 	ASFLAGS \
 	LDFLAGS \
 	LIBS \
-	LIBDIRS \
+	LIBPATHS \
 	_3DSXFLAGS \
-	OFILES
+	OFILES \
+	LD
 $(call override_values,$(VARS_TO_OVERRIDE))
+
+$(BUILD_OUTPUT).elf: $(BUILD_OFILES)
+$(TEST_OUTPUT).elf: $(TEST_OFILES)
 
 # Nullifies the APP_ICON prerequisite of %.smdh
 APP_ICON = $(DUMMY_APP_ICON)
@@ -294,14 +333,11 @@ MAKEROMFLAGS = -rsf $(RFS_FILE) -elf $*.elf -DROMFS=$(ROMFS) -DTITLE=$(TITLE) \
 # stuff. The reason why I'm patching 3ds_rules is that it also includes base_rules.
 #---------------------------------------------------------------------------------
 
-$(BASE_RULES): $(DEVKITARM)/base_rules
+$(BASE_RULES): $(DEVKITARM)/base_rules | $(dir $(BASE_RULES))
 	@sed 's|^%|$(OFILES_DIR)/%|g' $< > $@
 
-$(_3DS_RULES): $(DEVKITARM)/3ds_rules
+$(_3DS_RULES): $(DEVKITARM)/3ds_rules | $(dir $(_3DS_RULES))
 	@sed '/include/d' $< > $@
-
-include $(BASE_RULES)
-include $(_3DS_RULES)
 
 #---------------------------------------------------------------------------------
 # you need a rule like this for each extension you use as binary data

--- a/make/AssertEnvironment
+++ b/make/AssertEnvironment
@@ -1,0 +1,6 @@
+include $(MAKEMODULES_DIR)/Utility
+
+$(call must_exist, DEVKITARM)
+$(call must_exist, DEVKITPRO)
+
+CTRULIB ?= $(DEVKITPRO)/libctru

--- a/make/AssertParameters
+++ b/make/AssertParameters
@@ -1,0 +1,8 @@
+# This script ensures that the root Makefile was called with all required variables
+include $(MAKEMODULES_DIR)/Utility
+
+$(call must_exist, CAPTURE_INCLUDES)
+$(call must_exist, CAPTURE_SOURCES)
+$(call must_exist, CAPTURE_BUILD)
+$(call must_exist, DEVKITARM)
+$(call must_exist, DEVKITPRO)

--- a/make/AssertParameters
+++ b/make/AssertParameters
@@ -4,5 +4,3 @@ include $(MAKEMODULES_DIR)/Utility
 $(call must_exist, CAPTURE_INCLUDES)
 $(call must_exist, CAPTURE_SOURCES)
 $(call must_exist, CAPTURE_BUILD)
-$(call must_exist, DEVKITARM)
-$(call must_exist, DEVKITPRO)

--- a/make/Utility
+++ b/make/Utility
@@ -1,5 +1,12 @@
 # Defines a few utility functions
 
+# Assigns "," to $(,) and " " to $( )
+, := ,
+__SPACE :=
+__SPACE +=
+$(__SPACE) :=
+$(__SPACE) +=
+
 # Cancels execution if a variable is not set.
 must_exist = $(if $(value $(strip $(1))),,$(error "Please export $1."))
 
@@ -33,18 +40,49 @@ $(foreach ext,$(1),$(call read_files_by_extension,BUILD,$(ext),SOURCES));
 $(foreach ext,$(1),$(call read_files_by_extension,TEST,$(ext),SOURCES));
 endef
 
+#---------------------------------------------------------------------------------
+#			config_option_t
+# Summary:
+#	Defines a configuration option for BUILD and TEST targets.
+#
+# Parameters:
+#	$1:	A list of flags to control processing of the options
+#	$2:	The name of the variables to be assigned
+#	$3:	The value for BUILD targets
+#	$4:	The value for TEST targets
+#
+# Description:
+#	This function creates the variables BUILD_$2 and TEST_$2 and assigns them
+#	their respective counterparts if they have not yet been set.
+#	The assignment is immediate if the `i` flag is given, otherwise it is
+#	deferred. Deferred assignments need to escape variable references.
+#	If the flag `e` is given the variable is added to `VARS_TO_OVERRIDE` which
+#	can then be used to inject variables into prerequisites for the specified
+#	target.
+#	If the flag `a` is given the value of BUILD_ is appended to TEST_.
+#---------------------------------------------------------------------------------
 define config_option_t =
 $(if $(findstring i,$1),$(eval BUILD_$2 := $(call or_default,BUILD_$2,$3)),$(eval BUILD_$2 ?= $3));
 $(if $(findstring i,$1),$(eval TEST_$2 := $(call or_default,TEST_$2,$4)$(if $(findstring a,$1), $(value BUILD_$2),))),$(eval TEST_$2 ?= $(if $(findstring a,$1),$(value BUILD_$2),));
 $(if $(findstring e,$1),$(eval VARS_TO_OVERRIDE += $2),)
 endef
 
+#---------------------------------------------------------------------------------
+#			config_option_s
+# Summary:
+#	Defines a configuration option, that is the same for all targets.
+#
+# Parameters:
+#	$1:	A list of flags to control processing of the options.
+#	$2:	The variable's name
+#	$3:	The value
+#
+# Description:
+#	This function creates the variable $2 and assigns it $3 if it has not been
+#	set.
+#	The assignment is immediate if the `i` flag is given and deferred otherwise.
+#	If the `i` flag isn't given variable references must be escaped.
+#---------------------------------------------------------------------------------
 define config_option_s =
 $(if $(findstring i,$1),$(eval $2 := $(call or_default,$2,$3)),$(eval $2 ?= $3))
 endef
-
-, := ,
-__SPACE :=
-__SPACE +=
-$(__SPACE) :=
-$(__SPACE) +=

--- a/make/Utility
+++ b/make/Utility
@@ -32,3 +32,19 @@ define read_files_by_extensions =
 $(foreach ext,$(1),$(call read_files_by_extension,BUILD,$(ext),SOURCES));
 $(foreach ext,$(1),$(call read_files_by_extension,TEST,$(ext),SOURCES));
 endef
+
+define config_option_t =
+$(if $(findstring i,$1),$(eval BUILD_$2 := $(call or_default,BUILD_$2,$3)),$(eval BUILD_$2 ?= $3));
+$(if $(findstring i,$1),$(eval TEST_$2 := $(call or_default,TEST_$2,$4)$(if $(findstring a,$1), $(value BUILD_$2),))),$(eval TEST_$2 ?= $(if $(findstring a,$1),$(value BUILD_$2),));
+$(if $(findstring e,$1),$(eval VARS_TO_OVERRIDE += $2),)
+endef
+
+define config_option_s =
+$(if $(findstring i,$1),$(eval $2 := $(call or_default,$2,$3)),$(eval $2 ?= $3))
+endef
+
+, := ,
+__SPACE :=
+__SPACE +=
+$(__SPACE) :=
+$(__SPACE) +=

--- a/make/Utility
+++ b/make/Utility
@@ -1,0 +1,34 @@
+# Defines a few utility functions
+
+# Cancels execution if a variable is not set.
+must_exist = $(if $(value $(strip $(1))),,$(error "Please export $1."))
+
+# Acts like ?=, but is immediate
+or_default = $(if $(value $(strip $(1))),$(value $(strip $(1))),$(strip $(2)))
+
+# Returns all files in 1 with extension 2.
+get_files = $(foreach dir,$(1),$(wildcard $(dir)/*.$(2)))
+
+# To transform TEST_NO_CIA into either nothing or TEST_CIA_NAME
+eval_no_target = $(eval $1_$2 := $(if $($(1)_NO_$(2)),,$($(1)_$(2)_NAME)))
+
+gen_3dsx_flags = $(eval $(1)_3DSXFLAGS := $(if $(value $(1)_ROMFS)), --romfs=$(BUILD_ROMFS)) $(if $(value $(1)_NO_SMDH),,--smdh=$(value $(1)_SMDH_NAME))
+
+# Overrides the variable 1 for all prereqs of the phony target for 2.
+define override_value =
+$(eval $$($(2)_TARGET): $(1) = $$($(2)_$(1)))
+endef
+
+define override_values =
+$(foreach var,$(1),$(call override_value,$(var),BUILD));
+$(foreach var,$(1),$(call override_value,$(var),TARGET))
+endef
+
+define read_files_by_extension =
+$(eval $(1)_$(subst .,,$(2)FILES := $(call get_files,$(value $(1)_$(3)),$(2))))
+endef
+
+define read_files_by_extensions =
+$(foreach ext,$(1),$(call read_files_by_extension,BUILD,$(ext),SOURCES));
+$(foreach ext,$(1),$(call read_files_by_extension,TEST,$(ext),SOURCES));
+endef


### PR DESCRIPTION
This PR reworks the Makefile to make capture embeddable and prevent collisions between object files. See the relevant issue for an overly long explanation.

(I also kinda did this so GitHub would show this in my contribution graph)

Closes #19.